### PR TITLE
support importing in a node env

### DIFF
--- a/src/qr-creator.js
+++ b/src/qr-creator.js
@@ -9,8 +9,7 @@ export default class QrCreator {
 }
 // avoid that closure compiler strips these away
 QrCreator['render'] = QrCreator.render;
-self['QrCreator'] = QrCreator;
-
+globalThis['QrCreator'] = QrCreator;
 
 /*! jquery-qrcode v0.14.0 - https://larsjung.de/jquery-qrcode/ */
 (function(vendor_qrcode) {


### PR DESCRIPTION
we can add `QrCreator` to `globalThis` rather than `self` which will have the same effect, but will allow for importing in non-browser environments